### PR TITLE
Cleaned up numbers and strings in grammar to make parsing easier.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build/
+
 # ANTLR4 build files
 *.class
 *.interp

--- a/README.md
+++ b/README.md
@@ -235,10 +235,11 @@ by a fractional part (decimal) and/or an exponent part.
   }
 ```
 
-## Implementations
+## Implementations  
 
-It's pretty empty here right now, but if you have an implementation, submit a pull request,
-adding it to this section. Please specify which version of the specification your implementation supports.
+If you have an implementation, submit a pull request, adding it to this section!   
+
+* Python - https://github.com/jeml-lang/jeml-py
 
 
 ## Contributing

--- a/examples/v100.jeml
+++ b/examples/v100.jeml
@@ -1,4 +1,3 @@
-
 # Examples for JEML v1.0.0
 
 # ---------------------------------------------------------------------------
@@ -157,5 +156,15 @@ floats {
     bar 455E-3
     fiz 3.14e-33
   }
+}
+
+# Binary, Octal, and Hexidecimal
+# ------------------------------
+# JEML also supports Binary, Octal, and Hexidecimal numbers.
+
+complex {
+  binary 0b1000101
+  octal 0o105
+  hexidecimal 0x4f
 }
 

--- a/jeml.g4
+++ b/jeml.g4
@@ -51,9 +51,18 @@ j_list
   | '[' ']'
   ;
 
-j_string : STRING ;
-j_bool : BOOLEAN ;
-j_number : NUMBER ;
+j_string  : STRING | MULTILINE_STRING ;
+j_bool    : BOOLEAN ;
+j_number  : ( j_octal | j_binary | j_hex | j_decimal | j_integer );
+
+// Numerical types
+j_octal   : OCTAL_NUMBER ;
+j_binary  : BINARY_NUMBER ;
+j_hex     : HEXIDECIMAL_NUMBER ;
+j_decimal : DECIMAL ;
+j_integer : INTEGER ;
+j_complex : j_binary | j_octal | j_hex ;
+
 
 /*
  * Lexer Rules
@@ -67,33 +76,16 @@ BOOLEAN
 
 STRING
   : '"' ( ESCAPE_SEQUENCE | SAFE_CODEPOINT )* '"'
-  | MULTILINE_STRING
   ;
 
-NUMBER
+INTEGER
+  : '-'? DIGIT_09 ( DIGIT_09+ )?
+  ;
+
+DECIMAL
   : '-'? DIGIT_09 ( '.' DIGIT_09+ )? EXPONENT?
   | DIGIT_09 ( '_' DIGIT_09 )*
   | '.' DIGIT_09 ( '_' DIGIT_09 )*
-  | SPECIAL_NUMBER
-  ;
-
-SPECIAL_NUMBER
-  : HEXIDECIMAL_NUMBER
-  | BINARY_NUMBER
-  | OCTAL_NUMBER
-  ;
-
-KEY
-  : ( ALPHA | DIGIT_09 | '-' | '_' | '?' )+
-  ;
-
-MULTILINE_STRING
-  /* : '"""' ( SAFE_CODEPOINT | ESCAPE_SEQUENCE | ~["\\] | . )*? '"""' */
-  : '"""' ( . )*? '"""'
-  ;
-
-EXPONENT
-  : [Ee] [+\-]? DIGIT_09
   ;
 
 HEXIDECIMAL_NUMBER
@@ -108,12 +100,23 @@ OCTAL_NUMBER
   : '0o' DIGIT_07 ( DIGIT_07 | '_' DIGIT_07 )*
   ;
 
+KEY
+  : ( ALPHA | DIGIT_09 | '-' | '_' | '?' | '!' )+
+  ;
+
+MULTILINE_STRING
+  : '"""' ( . )*? '"""'
+  ;
+
+EXPONENT
+  : [Ee] [+\-]? DIGIT_09
+  ;
+
 fragment ESCAPE_SEQUENCE : '\\' ( ["\\/bfnrt] ) ;
 fragment SAFE_CODEPOINT  : ~["\\\u0000-\u001F] ;
 
 fragment ALPHA           : [A-Za-z] ;
 fragment DIGIT_09        : [0-9]+ ;
-fragment DIGIT_19        : [1-9]+ ;
 fragment DIGIT_07        : [0-7]+ ;
 fragment DIGIT_01        : [0-1]+ ;
 fragment HEXIDECIMAL     : [A-Fa-f] | DIGIT_09 ;


### PR DESCRIPTION
Beforehand, complex numbers were grouped together as `NUMBERS`. This made it difficult for parsers to easily typecheck. Now complex numbers, decimals, and integers are labeled properly in the AST, thus making typechecking a simple operation. Strings were fixed in a similar way, now being labeled as `STRING` or `MULTILINE_STRING`.

Additionally:  
- Added complex number example to `v100.jeml`
- Added jeml-py to readme